### PR TITLE
feat(haskell): update haskell-tools version and add ormolu

### DIFF
--- a/lua/lazyvim/plugins/extras/lang/haskell.lua
+++ b/lua/lazyvim/plugins/extras/lang/haskell.lua
@@ -14,11 +14,50 @@ return {
 
   {
     "mrcjkb/haskell-tools.nvim",
-    version = "^3",
+    version = "^6",
     ft = { "haskell", "lhaskell", "cabal", "cabalproject" },
     dependencies = {
       { "nvim-telescope/telescope.nvim", optional = true },
     },
+    keys = {
+      {
+        "<leader>ce",
+        ft = "haskell",
+        "<cmd>HlsEvalAll<cr>",
+        desc = "Haskell Evaluate All",
+      },
+      {
+        "<leader>so",
+        ft = "haskell",
+        function()
+          require("haskell-tools").hoogle.hoogle_signature()
+        end,
+        desc = "Hoogle (Function Signature)",
+      },
+      {
+        "<leader>sO",
+        ft = "haskell",
+        "<cmd>Telescope hoogle<cr>",
+        desc = "Hoogle (Global)",
+      },
+      {
+        "<leader>fl",
+        ft = "haskell",
+        function()
+          require("haskell-tools").repl.toggle()
+        end,
+        desc = "GHCi REPL (Package)",
+      },
+      {
+        "<leader>fL",
+        ft = "haskell",
+        function()
+          require("haskell-tools").repl.toggle(vim.api.nvim_buf_get_name(0))
+        end,
+        desc = "GHCi REPL (Current File)",
+      },
+    },
+  },
     config = function()
       local ok, telescope = pcall(require, "telescope")
       if ok then
@@ -78,6 +117,16 @@ return {
         telescope.load_extension("hoogle")
       end
     end,
+  },
+
+  {
+    "stevearc/conform.nvim",
+    optional = true,
+    opts = {
+      formatters_by_ft = {
+        haskell = { "ormolu" },
+      },
+    },
   },
 
   -- Make sure lspconfig doesn't start hls,


### PR DESCRIPTION
## Description

- Updates `haskell-tools` to use the recommended version in the plugin's README
- Adds `ormolu` as a formatter
- Adds keybindings for `haskell-tools` that does not conflict with LazyVim's defaults.

## Related Issue(s)

- https://github.com/LazyVim/LazyVim/discussions/3325#discussioncomment-9562683: adds `ormolu` formatter.
- https://github.com/LazyVim/LazyVim/pull/2052#issuecomment-2881764491: @mrcjkb keeps getting bug reports because the version is still in `3` and should be updated to `6`.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
